### PR TITLE
Ensure entity visibility operations run safely on main thread

### DIFF
--- a/src/main/java/com/magmaguy/freeminecraftmodels/customentity/DynamicEntity.java
+++ b/src/main/java/com/magmaguy/freeminecraftmodels/customentity/DynamicEntity.java
@@ -62,11 +62,22 @@ public class DynamicEntity extends ModeledEntity implements ModeledEntityInterfa
         DynamicEntity dynamicEntity = new DynamicEntity(entityID, livingEntity.getLocation());
         dynamicEntity.spawn(livingEntity);
         livingEntity.setVisibleByDefault(false);
-        Bukkit.getOnlinePlayers().forEach(player -> {
-            if (player.getLocation().getWorld().equals(dynamicEntity.getLocation().getWorld())) {
-                player.hideEntity(MetadataHandler.PLUGIN, livingEntity);
-            }
-        });
+        // Must run on main thread
+        if (Bukkit.isPrimaryThread()) {
+            Bukkit.getOnlinePlayers().forEach(player -> {
+                if (player.getLocation().getWorld().equals(dynamicEntity.getLocation().getWorld())) {
+                    player.hideEntity(MetadataHandler.PLUGIN, livingEntity);
+                }
+            });
+        } else {
+            Bukkit.getScheduler().runTask(MetadataHandler.PLUGIN, () -> {
+                Bukkit.getOnlinePlayers().forEach(player -> {
+                    if (player.getLocation().getWorld().equals(dynamicEntity.getLocation().getWorld())) {
+                        player.hideEntity(MetadataHandler.PLUGIN, livingEntity);
+                    }
+                });
+            });
+        }
 
         livingEntity.getPersistentDataContainer().set(namespacedKey, PersistentDataType.BYTE, (byte) 0);
         return dynamicEntity;

--- a/src/main/java/com/magmaguy/freeminecraftmodels/customentity/ModeledEntity.java
+++ b/src/main/java/com/magmaguy/freeminecraftmodels/customentity/ModeledEntity.java
@@ -234,14 +234,34 @@ public class ModeledEntity {
 
     public void showUnderlyingEntity(Player player) {
         if (underlyingEntity == null || !underlyingEntity.isValid()) return;
-        player.showEntity(MetadataHandler.PLUGIN, underlyingEntity);
-        underlyingEntity.setGlowing(true);
+        // Must run on main thread
+        if (Bukkit.isPrimaryThread()) {
+            player.showEntity(MetadataHandler.PLUGIN, underlyingEntity);
+            underlyingEntity.setGlowing(true);
+        } else {
+            Bukkit.getScheduler().runTask(MetadataHandler.PLUGIN, () -> {
+                if (underlyingEntity != null && underlyingEntity.isValid() && player.isOnline()) {
+                    player.showEntity(MetadataHandler.PLUGIN, underlyingEntity);
+                    underlyingEntity.setGlowing(true);
+                }
+            });
+        }
     }
 
     public void hideUnderlyingEntity(Player player) {
         if (underlyingEntity == null || !underlyingEntity.isValid()) return;
-        player.hideEntity(MetadataHandler.PLUGIN, underlyingEntity);
-        underlyingEntity.setGlowing(false);
+        // Must run on main thread
+        if (Bukkit.isPrimaryThread()) {
+            player.hideEntity(MetadataHandler.PLUGIN, underlyingEntity);
+            underlyingEntity.setGlowing(false);
+        } else {
+            Bukkit.getScheduler().runTask(MetadataHandler.PLUGIN, () -> {
+                if (underlyingEntity != null && underlyingEntity.isValid() && player.isOnline()) {
+                    player.hideEntity(MetadataHandler.PLUGIN, underlyingEntity);
+                    underlyingEntity.setGlowing(false);
+                }
+            });
+        }
     }
 
     /**

--- a/src/main/java/com/magmaguy/freeminecraftmodels/customentity/PlayerDisguiseEntity.java
+++ b/src/main/java/com/magmaguy/freeminecraftmodels/customentity/PlayerDisguiseEntity.java
@@ -22,11 +22,22 @@ public class PlayerDisguiseEntity extends DynamicEntity {
         PlayerDisguiseEntity dynamicEntity = new PlayerDisguiseEntity(entityID, targetPlayer.getLocation());
         dynamicEntity.spawn(targetPlayer);
         targetPlayer.setVisibleByDefault(false);
-        Bukkit.getOnlinePlayers().forEach(player -> {
-            if (player.getLocation().getWorld().equals(dynamicEntity.getLocation().getWorld())) {
-                player.hideEntity(MetadataHandler.PLUGIN, targetPlayer);
-            }
-        });
+        // Must run on main thread
+        if (Bukkit.isPrimaryThread()) {
+            Bukkit.getOnlinePlayers().forEach(player -> {
+                if (player.getLocation().getWorld().equals(dynamicEntity.getLocation().getWorld())) {
+                    player.hideEntity(MetadataHandler.PLUGIN, targetPlayer);
+                }
+            });
+        } else {
+            Bukkit.getScheduler().runTask(MetadataHandler.PLUGIN, () -> {
+                Bukkit.getOnlinePlayers().forEach(player -> {
+                    if (player.getLocation().getWorld().equals(dynamicEntity.getLocation().getWorld())) {
+                        player.hideEntity(MetadataHandler.PLUGIN, targetPlayer);
+                    }
+                });
+            });
+        }
         targetPlayer.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 1));
         return dynamicEntity;
     }

--- a/src/main/java/com/magmaguy/freeminecraftmodels/customentity/core/SkeletonWatchers.java
+++ b/src/main/java/com/magmaguy/freeminecraftmodels/customentity/core/SkeletonWatchers.java
@@ -224,8 +224,14 @@ public class SkeletonWatchers implements Listener {
 
     private void displayTo(Player player) {
         boolean isBedrock = BedrockChecker.isBedrock(player);
-        if (isBedrock && !DefaultConfig.sendCustomModelsToBedrockClients && skeleton.getModeledEntity().getUnderlyingEntity() != null)
-            player.showEntity(MetadataHandler.PLUGIN, skeleton.getModeledEntity().getUnderlyingEntity());
+        if (isBedrock && !DefaultConfig.sendCustomModelsToBedrockClients && skeleton.getModeledEntity().getUnderlyingEntity() != null) {
+            // Must run on main thread
+            Bukkit.getScheduler().runTask(MetadataHandler.PLUGIN, () -> {
+                if (player.isOnline() && player.isValid()) {
+                    player.showEntity(MetadataHandler.PLUGIN, skeleton.getModeledEntity().getUnderlyingEntity());
+                }
+            });
+        }
         viewers.add(player.getUniqueId());
         skeleton.getBones().forEach(bone -> bone.displayTo(player));
         if (skeleton.getModeledEntity() instanceof PropEntity propEntity)
@@ -233,11 +239,18 @@ public class SkeletonWatchers implements Listener {
     }
 
     private void hideFrom(UUID uuid) {
-        boolean isBedrock = BedrockChecker.isBedrock(Bukkit.getPlayer(uuid));
         Player player = Bukkit.getPlayer(uuid);
         if (player == null || !player.isValid()) return;
-        if (isBedrock && !DefaultConfig.sendCustomModelsToBedrockClients && skeleton.getModeledEntity().getUnderlyingEntity() != null)
-            player.hideEntity(MetadataHandler.PLUGIN, skeleton.getModeledEntity().getUnderlyingEntity());
+        
+        boolean isBedrock = BedrockChecker.isBedrock(player);
+        if (isBedrock && !DefaultConfig.sendCustomModelsToBedrockClients && skeleton.getModeledEntity().getUnderlyingEntity() != null) {
+            // Must run on main thread
+            Bukkit.getScheduler().runTask(MetadataHandler.PLUGIN, () -> {
+                if (player.isOnline() && player.isValid()) {
+                    player.hideEntity(MetadataHandler.PLUGIN, skeleton.getModeledEntity().getUnderlyingEntity());
+                }
+            });
+        }
         viewers.remove(uuid);
         skeleton.getBones().forEach(bone -> bone.hideFrom(uuid));
         if (skeleton.getModeledEntity() instanceof PropEntity propEntity)


### PR DESCRIPTION
This PR addresses a concurrency issue where entity visibility methods (showEntity, hideEntity, etc.) were being called from non-primary threads, potentially causing thread-safety violations or runtime exceptions on Bukkit-based servers.

The changes enforce that all visibility updates are executed on the main thread, using Bukkit.isPrimaryThread() checks and Bukkit.getScheduler().runTask(...) scheduling when necessary.

Exampel of logs erros fixes: https://mclo.gs/rrAXuPM
